### PR TITLE
Fix typescript compile error

### DIFF
--- a/src/wallet_address_validator.d.ts
+++ b/src/wallet_address_validator.d.ts
@@ -4,8 +4,8 @@ declare module 'trezor-address-validator' {
         symbol: string,
     }
 
-    export declare function validate(address: string, currencyNameOrSymbol: string, networkType?: string): boolean;
-    export declare function getCurrencies(): Currency[];
-    export declare function findCurrency(symbol: string): Currency
+    export function validate(address: string, currencyNameOrSymbol: string, networkType?: string): boolean;
+    export function getCurrencies(): Currency[];
+    export function findCurrency(symbol: string): Currency
 }
 


### PR DESCRIPTION
Compiler throws `'declare' modifier not allowed for code already in ambient context`