### PR TITLE
Fix issue with stellar address validation

### DIFF
--- a/src/crypto/utils.js
+++ b/src/crypto/utils.js
@@ -7,12 +7,8 @@ var base32 = require('./base32');
 var BigNum = require('browserify-bignum');
 var groestl = require('groestl-hash-js');
 
-function numberToHex(number) {
-    var hex = Math.round(number).toString(16)
-    if (hex.length === 1) {
-        hex = '0' + hex
-    }
-    return hex
+function numberToHex(number, sizeInBytes) {
+    return Math.round(number).toString(16).padStart(sizeInBytes * 2, '0');
 }
 
 function isHexChar(c) {
@@ -80,10 +76,11 @@ function hexStr2byteArray(str) {
 }
 
 module.exports = {
+    numberToHex,
     toHex: function (arrayOfBytes) {
         var hex = '';
         for (var i = 0; i < arrayOfBytes.length; i++) {
-            hex += numberToHex(arrayOfBytes[i]);
+            hex += numberToHex(arrayOfBytes[i], 1);
         }
         return hex;
     },

--- a/src/stellar_validator.js
+++ b/src/stellar_validator.js
@@ -14,14 +14,6 @@ function swap16(number) {
     return (lower << 8) | upper;
 }
 
-function numberToHex(number) {
-    let hex = number.toString(16);
-    if (hex.length % 2 === 1) {
-        hex = '0' + hex;
-    }
-    return hex;
-}
-
 module.exports = {
     isValidAddress: function (address) {
         if (regexp.test(address)) {
@@ -32,15 +24,15 @@ module.exports = {
     },
 
      verifyChecksum: function (address) {
-        // based on https://github.com/stellar/js-stellar-base/blob/master/src/strkey.js#L126
+        // based on https://github.com/stellar/js-stellar-base/blob/master/src/strkey.js
         const bytes = base32.decode(address);
         if (bytes[0] !== ed25519PublicKeyVersionByte) {
             return false;
         }
 
-        const computedChecksum = numberToHex(swap16(crc.crc16xmodem(bytes.slice(0, -2))));
+        const payload = bytes.slice(0, -2);
         const checksum = cryptoUtils.toHex(bytes.slice(-2));
-
-        return computedChecksum === checksum
+        const computedChecksum = cryptoUtils.numberToHex(swap16(crc.crc16xmodem(payload)), 2);
+        return computedChecksum === checksum;
     }
 };

--- a/src/stellar_validator.js
+++ b/src/stellar_validator.js
@@ -1,46 +1,46 @@
-var baseX = require('base-x');
-var crc = require('crc');
-var cryptoUtils = require('./crypto/utils');
+const baseX = require('base-x');
+const crc = require('crc');
+const cryptoUtils = require('./crypto/utils');
 
- var ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
- var base32 = baseX(ALPHABET);
-var regexp = new RegExp('^[' + ALPHABET + ']{56}$');
-var ed25519PublicKeyVersionByte = (6 << 3);
+const base32 = baseX(ALPHABET);
+const regexp = new RegExp('^[' + ALPHABET + ']{56}$');
+const ed25519PublicKeyVersionByte = (6 << 3);
 
- function swap16(number) {
-    var lower = number & 0xFF;
-    var upper = (number >> 8) & 0xFF;
+function swap16(number) {
+    const lower = number & 0xFF;
+    const upper = (number >> 8) & 0xFF;
     return (lower << 8) | upper;
 }
 
- function numberToHex(number) {
-    var hex = number.toString(16);
-    if(hex.length % 2 === 1) {
+function numberToHex(number) {
+    let hex = number.toString(16);
+    if (hex.length % 2 === 1) {
         hex = '0' + hex;
     }
     return hex;
 }
 
- module.exports = {
+module.exports = {
     isValidAddress: function (address) {
         if (regexp.test(address)) {
             return this.verifyChecksum(address);
         }
 
-         return false;
+        return false;
     },
 
      verifyChecksum: function (address) {
         // based on https://github.com/stellar/js-stellar-base/blob/master/src/strkey.js#L126
-        var bytes = base32.decode(address);
+        const bytes = base32.decode(address);
         if (bytes[0] !== ed25519PublicKeyVersionByte) {
             return false;
         }
 
-         var computedChecksum = numberToHex(swap16(crc.crc16xmodem(bytes.slice(0, -2))));
-        var checksum = cryptoUtils.toHex(bytes.slice(-2));
+        const computedChecksum = numberToHex(swap16(crc.crc16xmodem(bytes.slice(0, -2))));
+        const checksum = cryptoUtils.toHex(bytes.slice(-2));
 
-         return computedChecksum === checksum
+        return computedChecksum === checksum
     }
 };

--- a/test/wallet_address_validator.js
+++ b/test/wallet_address_validator.js
@@ -66,10 +66,10 @@ describe('WAValidator.validate()', function () {
 
         it('should return true for correct bitcoincash addresses', function () {
             valid('bitcoincash:qq4v32mtagxac29my6gwj6fd4tmqg8rysu23dax807', 'bch');
-            valid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch');            
-            valid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch');            
-            valid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch', 'testnet');            
-            valid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch', 'testnet');            
+            valid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch');
+            valid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch');
+            valid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch', 'testnet');
+            valid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyy', 'bch', 'testnet');
         });
 
         it('should return true for correct litecoin addresses', function () {
@@ -81,7 +81,7 @@ describe('WAValidator.validate()', function () {
 
             // p2sh addresses
             valid('MUWheVyCBf3Fm3WNNXvotQ3Gj8NTSZCBVe', 'litecoin');
-            
+
             valid('2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7', 'litecoin', 'testnet');
             valid('QW2SvwjaJU8LD6GSmtm1PHnBG2xPuxwZFy', 'litecoin', 'testnet');
             valid('QjpzxpbLp5pCGsCczMbfh1uhC3P89QZavY', 'litecoin', 'testnet');
@@ -385,7 +385,7 @@ describe('WAValidator.validate()', function () {
             valid('4swhHtxKapQbj3TZEipgtp7NQzcRWDYqCxXYoPQWjGyHmhxS1w1TjUEszCQT1sQucGwmPQMYdv1FYs3d51KgoubviPBf', 'cardano');
             valid('addr1qxnv5u3vrx2t37h3u27qd5ukgcjmrl4f8mu9f5sza3h20cxsfjh80un9kvlggfcdw8fp5kqp9tztqnee9msd0qsafhdsyqclvk', 'cardano');
             valid('ADDR1QXNV5U3VRX2T37H3U27QD5UKGCJMRL4F8MU9F5SZA3H20CXSFJH80UN9KVLGGFCDW8FP5KQP9TZTQNEE9MSD0QSAFHDSYQCLVK', 'cardano');
-            valid('addr1qxclz0u9guazk70l9vv3xf67wx3psx3dekasvy43xfvz56qcs6f7ssw2x0fcesudyj8h224rnzkae2lqlnw8f3353t3sjggfx0', 'cardano');            
+            valid('addr1qxclz0u9guazk70l9vv3xf67wx3psx3dekasvy43xfvz56qcs6f7ssw2x0fcesudyj8h224rnzkae2lqlnw8f3353t3sjggfx0', 'cardano');
         });
 
         it('should return true for correct monero addresses', function () {
@@ -641,6 +641,7 @@ describe('WAValidator.validate()', function () {
             valid('GACXQEAXYBEZLBMQ2XETOBRO4P66FZAJENDHOQRYPUIXZIIXLKMZEXBJ', 'stellar');
             valid('GDD3XRXU3G4DXHVRUDH7LJM4CD4PDZTVP4QHOO4Q6DELKXUATR657OZV', 'stellar');
             valid('GDTYVCTAUQVPKEDZIBWEJGKBQHB4UGGXI2SXXUEW7LXMD4B7MK37CWLJ', 'stellar');
+            valid('GDC5UWE3G6Z4KYOTET5NOCRIVBKWH7MOCSPZPHF4GHQ6XUDD27ACOACD', 'stellar');
         });
 
         it('should return true for correct binance address', function () {
@@ -705,8 +706,8 @@ describe('WAValidator.validate()', function () {
             invalid('3NJZLcZEEYBpxYEUGewU4knsQRn1WM5Fkt', 'bitcoincash');
             invalid('2MxKEf2su6FGAUfCEAHreGFQvEYrfYNHvL7', 'bitcoincash', 'testnet');
             // bitcoincash
-            invalid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyya', 'bch');            
-            invalid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyya', 'bch');            
+            invalid('bitcoincash:qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyya', 'bch');
+            invalid('qp3wjpa3tjlj042z2wv7hahsldgwhwy0rq9sywjpyya', 'bch');
         });
 
         it('should return false for incorrect litecoin addresses', function () {
@@ -1020,7 +1021,7 @@ describe('WAValidator.validate()', function () {
             invalid('xrb_1111111112111111111111111111111111111111111111111111hifc8npp', 'bnb');
             invalid('nano_111111111111111111111111111111111111111111111111111hifc8npp', 'bnb');
         });
-        
+
         it('should return false for incorrect xtz(tezos) address', function () {
             commonTests('xtz');
             invalid('SBGWKM3CD4IL47QN6X54N6Y33T3JDNVI6AIJ6CD5IM47HG3IG4O36XCU', 'xtz');


### PR DESCRIPTION
This fixes validation of Stellar addresses where the upper byte of the 16-bit integer checksum is 0x00.

Example address: https://stellar.expert/explorer/public/account/GDC5UWE3G6Z4KYOTET5NOCRIVBKWH7MOCSPZPHF4GHQ6XUDD27ACOACD