### PR TITLE
chore: deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Deprecated:
+
+Moved to trezor-suite repo https://github.com/trezor/trezor-suite/pull/9337
+
 # trezor-address-validator
 Simple wallet address validator for validating Bitcoin and other altcoins addresses in **Node.js and browser**.
 


### PR DESCRIPTION
Moved to trezor-suite repo https://github.com/trezor/trezor-suite/pull/9337

does anybody use it in production from npm? 

if yes, we should re-release it again under @trezor/ org